### PR TITLE
Added --verbose option

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var lib = require('./lib');
 
 function runTransforms(settings, transforms, files) {
 	return Promise.mapSeries(transforms, function (transform) {
-		return Runner.run(transform, files, {silent: settings.silent, verbose:settings.verbose});
+		return Runner.run(transform, files, {silent: settings.silent, verbose: settings.verbose});
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var lib = require('./lib');
 
 function runTransforms(settings, transforms, files) {
 	return Promise.mapSeries(transforms, function (transform) {
-		return Runner.run(transform, files, {silent: settings.silent});
+		return Runner.run(transform, files, {silent: settings.silent, verbose:settings.verbose});
 	});
 }
 
@@ -27,6 +27,7 @@ function cliArgs(settings, releases) {
 		'  --to <version>   Specify the version of ' + settings.libraryName + ' to move to',
 		'  --force, -f      Bypass safety checks and forcibly run codemods',
 		'  --silent, -S     Disable log output',
+		'  --verbose, -v    Verbose logging',
 		'',
 		'Available upgrades'
 	].concat(upgrades);
@@ -42,6 +43,7 @@ function cliArgs(settings, releases) {
 		alias: {
 			f: 'force',
 			S: 'silent',
+			v: 'verbose',
 			h: 'help'
 		}
 	});


### PR DESCRIPTION
When code has an error and it can't be parsed, show see an error count, but cannot see the actual error. With the verbose option in jscodeshift enable this error will be shown. So add an option for that to enable verbose.

Found this when using lodash-codemods on ES5 code with `var package;`. The code works in node, but the keyword package is reserved, so the parser failed here but the error was hidden.
