### PR TITLE
Set verbose option to always show errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var lib = require('./lib');
 
 function runTransforms(settings, transforms, files) {
 	return Promise.mapSeries(transforms, function (transform) {
-		return Runner.run(transform, files, {silent: settings.silent});
+		return Runner.run(transform, files, {silent: settings.silent, verbose: 0});
 	});
 }
 


### PR DESCRIPTION
See #6 . Errors from `jscodeshift` are lost now, set verbose option to always show errors.
